### PR TITLE
feat: change variable definition msi_auth_for_monitoring_enabled 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
     content {
       log_analytics_workspace_id      = try(var.cluster.workspace.id, null)
-      msi_auth_for_monitoring_enabled = try(oms_agent.value.msi_auth_for_monitoring_enabled, false)
+      msi_auth_for_monitoring_enabled = try(var.cluster.workspace.enable.msi_auth_for_monitoring_enabled, false)
     }
   }
 


### PR DESCRIPTION
Changing the value of the msi_auth_for_monitoring_enabled boolean seemed complicated to figure out, changed it to a variable in the cluster.workspace.enable variable to make it more straightforward