### PR TITLE
feat: additional node pool settings, single auto scaler profile and api server access

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -8,7 +8,7 @@ locals {
       max_count      = try(pools.max_count, 0)
       min_count      = try(pools.min_count, 0)
       max_surge      = try(pools.max_surge, 50)
-      poolname       = "aks${pools_key}"
+      poolname       = try(pools.name, "aks${pools_key}")
       aks_cluster_id = azurerm_kubernetes_cluster.aks.id
 
       linux_os_config = try(pools.config.linux_os, {
@@ -48,6 +48,9 @@ locals {
       enable_host_encryption = try(pools.enable.host_encryption, false)
       availability_zones     = try(pools.availability_zones, [])
       vnet_subnet_id         = try(pools.vnet_subnet_id, null)
+      os_disk_type           = try(pools.os_disk_type, null)
+      os_disk_size_gb        = try(pools.os_disk_size_gb, null)
+      orchestrator_version   = try(pools.orchestrator_version, null)
 
       custom_ca_trust = try(pools.custom_ca_trust, false)
       tags            = try(pools.tags, {})

--- a/main.tf
+++ b/main.tf
@@ -160,16 +160,16 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 
-  dynamic "linux_profile" {
-    for_each = var.cluster.profile == "linux" ? { "default" = {} } : {}
+  # dynamic "linux_profile" {
+  #   for_each = var.cluster.profile == "linux" ? { "default" = {} } : {}
 
-    content {
-      admin_username = try(var.linux_admin_username, "nodeadmin")
-      ssh_key {
-        key_data = azurerm_key_vault_secret.tls_public_key_secret[linux_profile.key].value
-      }
-    }
-  }
+  #   content {
+  #     admin_username = try(var.linux_admin_username, "nodeadmin")
+  #     ssh_key {
+  #       key_data = azurerm_key_vault_secret.tls_public_key_secret[linux_profile.key].value
+  #     }
+  #   }
+  # }
 
   dynamic "maintenance_window" {
     for_each = try(var.cluster.maintenance.general, null) != null ? { "default" = var.cluster.maintenance.general } : {}

--- a/main.tf
+++ b/main.tf
@@ -164,16 +164,16 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 
-  # dynamic "linux_profile" {
-  #   for_each = var.cluster.profile == "linux" ? { "default" = {} } : {}
+  dynamic "linux_profile" {
+    for_each = var.cluster.profile == "linux" ? { "default" = {} } : {}
 
-  #   content {
-  #     admin_username = try(var.linux_admin_username, "nodeadmin")
-  #     ssh_key {
-  #       key_data = azurerm_key_vault_secret.tls_public_key_secret[linux_profile.key].value
-  #     }
-  #   }
-  # }
+    content {
+      admin_username = try(var.cluster.linux_admin_username, "nodeadmin")
+      ssh_key {
+        key_data = azurerm_key_vault_secret.tls_public_key_secret[linux_profile.key].value
+      }
+    }
+  }
 
   dynamic "maintenance_window" {
     for_each = try(var.cluster.maintenance.general, null) != null ? { "default" = var.cluster.maintenance.general } : {}
@@ -441,6 +441,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "pools" {
   snapshot_id            = each.value.snapshot_id
   workload_runtime       = each.value.workload_runtime
   vnet_subnet_id         = each.value.vnet_subnet_id
+  os_disk_type           = each.value.os_disk_type
+  os_disk_size_gb        = each.value.os_disk_size_gb
+  orchestrator_version   = each.value.orchestrator_version
 
   dynamic "windows_profile" {
     for_each = each.value.os_type == "windows" ? [1] : []

--- a/main.tf
+++ b/main.tf
@@ -79,24 +79,28 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 
-  auto_scaler_profile {
-    balance_similar_node_groups      = try(var.cluster.auto_scaler_profile.balance_similar_node_groups, false)
-    expander                         = try(var.cluster.auto_scaler_profile.expander, null)
-    max_graceful_termination_sec     = try(var.cluster.auto_scaler_profile.max_graceful_termination_sec, null)
-    max_node_provisioning_time       = try(var.cluster.auto_scaler_profile.max_node_provisioning_time, null)
-    max_unready_nodes                = try(var.cluster.auto_scaler_profile.max_unready_nodes, null)
-    max_unready_percentage           = try(var.cluster.auto_scaler_profile.max_unready_percentage, null)
-    new_pod_scale_up_delay           = try(var.cluster.auto_scaler_profile.new_pod_scale_up_delay, null)
-    scale_down_delay_after_add       = try(var.cluster.auto_scaler_profile.scale_down_delay_after_add, null)
-    scale_down_delay_after_delete    = try(var.cluster.auto_scaler_profile.scale_down_delay_after_delete, null)
-    scale_down_delay_after_failure   = try(var.cluster.auto_scaler_profile.scale_down_delay_after_failure, null)
-    scan_interval                    = try(var.cluster.auto_scaler_profile.scan_interval, null)
-    scale_down_unneeded              = try(var.cluster.auto_scaler_profile.scale_down_unneeded, null)
-    scale_down_unready               = try(var.cluster.auto_scaler_profile.scale_down_unready, null)
-    scale_down_utilization_threshold = try(var.cluster.auto_scaler_profile.scale_down_utilization_threshold, null)
-    empty_bulk_delete_max            = try(var.cluster.auto_scaler_profile.empty_bulk_delete_max, null)
-    skip_nodes_with_local_storage    = try(var.cluster.auto_scaler_profile.skip_nodes_with_local_storage, null)
-    skip_nodes_with_system_pods      = try(var.cluster.auto_scaler_profile.skip_nodes_with_system_pods, null)
+  dynamic "auto_scaler_profile" {
+    for_each = var.cluster.auto_scaler_profile != null ? [1] : []
+
+    content {
+      balance_similar_node_groups      = try(var.cluster.auto_scaler_profile.balance_similar_node_groups, false)
+      expander                         = try(var.cluster.auto_scaler_profile.expander, null)
+      max_graceful_termination_sec     = try(var.cluster.auto_scaler_profile.max_graceful_termination_sec, null)
+      max_node_provisioning_time       = try(var.cluster.auto_scaler_profile.max_node_provisioning_time, null)
+      max_unready_nodes                = try(var.cluster.auto_scaler_profile.max_unready_nodes, null)
+      max_unready_percentage           = try(var.cluster.auto_scaler_profile.max_unready_percentage, null)
+      new_pod_scale_up_delay           = try(var.cluster.auto_scaler_profile.new_pod_scale_up_delay, null)
+      scale_down_delay_after_add       = try(var.cluster.auto_scaler_profile.scale_down_delay_after_add, null)
+      scale_down_delay_after_delete    = try(var.cluster.auto_scaler_profile.scale_down_delay_after_delete, null)
+      scale_down_delay_after_failure   = try(var.cluster.auto_scaler_profile.scale_down_delay_after_failure, null)
+      scan_interval                    = try(var.cluster.auto_scaler_profile.scan_interval, null)
+      scale_down_unneeded              = try(var.cluster.auto_scaler_profile.scale_down_unneeded, null)
+      scale_down_unready               = try(var.cluster.auto_scaler_profile.scale_down_unready, null)
+      scale_down_utilization_threshold = try(var.cluster.auto_scaler_profile.scale_down_utilization_threshold, null)
+      empty_bulk_delete_max            = try(var.cluster.auto_scaler_profile.empty_bulk_delete_max, null)
+      skip_nodes_with_local_storage    = try(var.cluster.auto_scaler_profile.skip_nodes_with_local_storage, null)
+      skip_nodes_with_system_pods      = try(var.cluster.auto_scaler_profile.skip_nodes_with_system_pods, null)
+    }
   }
 
   dynamic "http_proxy_config" {
@@ -269,10 +273,10 @@ resource "azurerm_kubernetes_cluster" "aks" {
     type                         = try(var.cluster.default_node_pool.type, "VirtualMachineScaleSets")
     workload_runtime             = try(var.cluster.default_node_pool.workload_runtime, null)
 
-    kubelet_disk_type    = try(var.cluster.default_node_pool.kubelet_disk_type, "OS")
-    os_disk_type         = try(var.cluster.default_node_pool.os_disk_type, "Managed")
-    os_disk_size_gb      = try(var.cluster.default_node_pool.os_disk_size_gb, "64")
-    orchestrator_version = try(var.cluster.default_node_pool.orchestrator_version, "1.27.3")
+    kubelet_disk_type    = try(var.cluster.default_node_pool.kubelet_disk_type, null)
+    os_disk_type         = try(var.cluster.default_node_pool.os_disk_type, null)
+    os_disk_size_gb      = try(var.cluster.default_node_pool.os_disk_size_gb, null)
+    orchestrator_version = try(var.cluster.default_node_pool.orchestrator_version, null)
 
     dynamic "upgrade_settings" {
       for_each = {

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,9 @@ variable "resourcegroup" {
   type        = string
   default     = null
 }
+
+variable "linux_admin_username" {
+  description = "the username of the linux administrator"
+  type        = string
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,9 +25,3 @@ variable "resourcegroup" {
   type        = string
   default     = null
 }
-
-variable "linux_admin_username" {
-  description = "the username of the linux administrator"
-  type        = string
-  default     = null
-}

--- a/variables.tf
+++ b/variables.tf
@@ -29,5 +29,5 @@ variable "resourcegroup" {
 variable "linux_admin_username" {
   description = "the username of the linux administrator"
   type        = string
-  default     = ""
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,3 +25,15 @@ variable "resourcegroup" {
   type        = string
   default     = null
 }
+
+variable "ssh_public_key_provided" {
+  description = "Decide whether the user brings their pre-existing ssh key"
+  type        = bool
+  default     = false
+}
+
+variable "ssh_public_key_keyvault_secret_name" {
+  description = "The secret name of the pre-existing ssh key"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
- Added settings to node pools:
os_disk_type
os_disk_size_gb
orchestrator_version

- Added nodepool name, so existing node pools are not renamed to "aks-<nodepool>"

- Changed auto scaler profile configuration since Terraform only allows one auto scaler profile

- Changed linux-profile-admin variable definition

- Changed oms.agent variable definition

- added optional api_server_access_profile element