### PR TITLE
fix: explicitly set fallback values for ssh key and admin password

### DIFF
--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -1,0 +1,75 @@
+This module enables flexible kubernetes cluster setup by supporting both auto generated and user supplied (bring your own) ssh keys and passwords for tailored access.
+
+## Usage: generated password or ssh key
+
+To utilize the generated password or ssh key, simply specify the key vault id in your configuration:
+
+```hcl
+module "aks" {
+  source  = "cloudnationhq/aks/azure"
+  version = "~> 0.1"
+
+  keyvault = module.kv.vault.id
+
+  cluster = {
+    name          = module.naming.kubernetes_cluster.name_unique
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+    depends_on    = [module.kv]
+    profile       = "linux"
+    dns_prefix    = "demo"
+  }
+}
+```
+
+## Usage: bringing your own password or ssh key
+
+To use your own password or SSH key, use the below properties in your configuration:
+
+```hcl
+module "aks-linux" {
+  source  = "cloudnationhq/aks/azure"
+  version = "~> 0.1"
+
+  keyvault = module.kv.vault.id
+
+  cluster = {
+    name               = "${module.naming.kubernetes_cluster.name}-02"
+    location           = module.rg.groups.demo.location
+    resourcegroup      = module.rg.groups.demo.name
+    node_resourcegroup = "${module.rg.groups.demo.name}-node02"
+    depends_on         = [module.kv]
+    profile            = "linux"
+    dns_prefix         = "demo2"
+    sku_tier           = "Standard"
+
+    public_key = module.kv.tls_public_keys.tls.value
+  }
+}
+```
+
+```hcl
+module "aks-windows" {
+  source  = "cloudnationhq/aks/azure"
+  version = "~> 0.1"
+
+  keyvault = module.kv.vault.id
+
+  cluster = {
+    name               = "${module.naming.kubernetes_cluster.name}-01"
+    location           = module.rg.groups.demo.location
+    resourcegroup      = module.rg.groups.demo.name
+    node_resourcegroup = "${module.rg.groups.demo.name}-node01"
+    depends_on         = [module.kv]
+    profile            = "windows"
+    dns_prefix         = "demo1"
+    sku_tier           = "Standard"
+
+    network_profile = {
+      network_plugin = "azure"
+    }
+
+    password = module.kv.secrets.password.value
+  }
+}
+```

--- a/examples/authentication/README.md
+++ b/examples/authentication/README.md
@@ -31,8 +31,6 @@ module "aks-linux" {
   source  = "cloudnationhq/aks/azure"
   version = "~> 0.1"
 
-  keyvault = module.kv.vault.id
-
   cluster = {
     name               = "${module.naming.kubernetes_cluster.name}-02"
     location           = module.rg.groups.demo.location
@@ -52,8 +50,6 @@ module "aks-linux" {
 module "aks-windows" {
   source  = "cloudnationhq/aks/azure"
   version = "~> 0.1"
-
-  keyvault = module.kv.vault.id
 
   cluster = {
     name               = "${module.naming.kubernetes_cluster.name}-01"

--- a/examples/authentication/locals.tf
+++ b/examples/authentication/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  naming = {
+    # lookup outputs to have consistent naming
+    for type in local.naming_types : type => lookup(module.naming, type).name
+  }
+
+  naming_types = ["key_vault_secret"]
+}

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -49,8 +49,6 @@ module "aks-windows" {
   source  = "cloudnationhq/aks/azure"
   version = "~> 0.1"
 
-  keyvault = module.kv.vault.id
-
   cluster = {
     name               = "${module.naming.kubernetes_cluster.name}-01"
     location           = module.rg.groups.demo.location
@@ -72,8 +70,6 @@ module "aks-windows" {
 module "aks-linux" {
   source  = "cloudnationhq/aks/azure"
   version = "~> 0.1"
-
-  keyvault = module.kv.vault.id
 
   cluster = {
     name               = "${module.naming.kubernetes_cluster.name}-02"

--- a/examples/authentication/main.tf
+++ b/examples/authentication/main.tf
@@ -1,0 +1,90 @@
+module "naming" {
+  source  = "cloudnationhq/naming/azure"
+  version = "~> 0.1"
+
+  suffix = ["demo", "dev"]
+}
+
+module "rg" {
+  source  = "cloudnationhq/rg/azure"
+  version = "~> 0.1"
+
+  groups = {
+    demo = {
+      name   = module.naming.resource_group.name
+      region = "westeurope"
+    }
+  }
+}
+
+module "kv" {
+  source  = "cloudnationhq/kv/azure"
+  version = "~> 0.1"
+
+  naming = local.naming
+
+  vault = {
+    name          = module.naming.key_vault.name_unique
+    location      = module.rg.groups.demo.location
+    resourcegroup = module.rg.groups.demo.name
+
+    secrets = {
+      tls_keys = {
+        tls = {
+          algorithm = "RSA"
+          key_size  = 2048
+        }
+      }
+      random_string = {
+        password = {
+          length  = 24
+          special = false
+        }
+      }
+    }
+  }
+}
+
+module "aks-windows" {
+  source  = "cloudnationhq/aks/azure"
+  version = "~> 0.1"
+
+  keyvault = module.kv.vault.id
+
+  cluster = {
+    name               = "${module.naming.kubernetes_cluster.name}-01"
+    location           = module.rg.groups.demo.location
+    resourcegroup      = module.rg.groups.demo.name
+    node_resourcegroup = "${module.rg.groups.demo.name}-node01"
+    depends_on         = [module.kv]
+    profile            = "windows"
+    dns_prefix         = "demo1"
+    sku_tier           = "Standard"
+
+    network_profile = {
+      network_plugin = "azure"
+    }
+
+    password = module.kv.secrets.password.value
+  }
+}
+
+module "aks-linux" {
+  source  = "cloudnationhq/aks/azure"
+  version = "~> 0.1"
+
+  keyvault = module.kv.vault.id
+
+  cluster = {
+    name               = "${module.naming.kubernetes_cluster.name}-02"
+    location           = module.rg.groups.demo.location
+    resourcegroup      = module.rg.groups.demo.name
+    node_resourcegroup = "${module.rg.groups.demo.name}-node02"
+    depends_on         = [module.kv]
+    profile            = "linux"
+    dns_prefix         = "demo2"
+    sku_tier           = "Standard"
+
+    public_key = module.kv.tls_public_keys.tls.value
+  }
+}

--- a/examples/authentication/terraform.tf
+++ b/examples/authentication/terraform.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.61"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
     content {
       admin_username = try(var.cluster.username, "nodeadmin")
-      admin_password = try(var.cluster.password, azurerm_key_vault_secret.secret[windows_profile.key].value)
+      admin_password = try(var.cluster.password, null) != null ? var.cluster.password : azurerm_key_vault_secret.secret["default"].value
     }
   }
 
@@ -209,7 +209,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     content {
       admin_username = try(var.cluster.username, "nodeadmin")
       ssh_key {
-        key_data = try(var.cluster.public_key, tls_private_key.tls_key[var.cluster.name].public_key_openssh)
+        key_data = try(var.cluster.public_key, null) != null ? var.cluster.public_key : tls_private_key.tls_key["default"].public_key_openssh
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "cluster" {
 variable "keyvault" {
   description = "keyvault to store secrets"
   type        = string
+  default     = null
 }
 
 variable "location" {


### PR DESCRIPTION
## Description

This bug fix enables the generation of SSH keys or passwords directly from the module, as well as from the keyvault module, without errors. I added some documentation regarding the different authentication use cases for clarity as well.

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #71 
