### PR TITLE
fix: fix validation error when deploying windows cluster with azure network plugin

### DIFF
--- a/examples/windows/main.tf
+++ b/examples/windows/main.tf
@@ -52,8 +52,8 @@ module "aks" {
       }
     }
 
-    network = {
-      plugin = "azure"
+    network_profile = {
+      network_plugin = "azure"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,7 +3,7 @@ variable "cluster" {
   type        = any
 
   validation {
-    condition     = contains(["windows", "linux"], lookup(var.cluster, "profile", "")) && (lookup(var.cluster, "profile", "") != "windows" || try(lookup(var.cluster.network, "plugin", "") == "azure", false))
+    condition     = contains(["windows", "linux"], lookup(var.cluster, "profile", "")) && (lookup(var.cluster, "profile", "") != "windows" || try(lookup(var.cluster.network_profile, "network_plugin", "") == "azure", false))
     error_message = "The aks profile must be either 'windows' or 'linux'. If the profile is 'windows', 'var.cluster.network.plugin' must be 'azure'."
   }
 }


### PR DESCRIPTION

## Description

Fixed validation error for Windows clusters by adjusting the validation condition to ensure that the network_plugin is set to azure when the profile is windows. Updated the validation logic in the cluster variable to enforce this constraint.

## PR Checklist

- [ ] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [ ] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [ ] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.

This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #73 
