### PR TITLE
fix: correct node_count assignment logic for AKS auto-scaling

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
     vm_size                       = var.cluster.default_node_pool.vm_size
     capacity_reservation_group_id = var.cluster.default_node_pool.capacity_reservation_group_id
     auto_scaling_enabled          = var.cluster.default_node_pool.auto_scaling_enabled
-    node_count                    = var.cluster.default_node_pool.auto_scaling_enabled != null ? null : var.cluster.default_node_pool.node_count
+    node_count                    = var.cluster.default_node_pool.auto_scaling_enabled ? null : var.cluster.default_node_pool.node_count
     min_count                     = var.cluster.default_node_pool.min_count
     max_count                     = var.cluster.default_node_pool.max_count
     host_encryption_enabled       = var.cluster.default_node_pool.host_encryption_enabled


### PR DESCRIPTION
## Description

This PR fixes a bug in the AKS default node pool scaling logic where node_count was being set to null whenever auto_scaling_enabled was non-null, which incorrectly broke manual scaling when users explicitly set auto_scaling_enabled = false; the change updates the expression so node_count is null only when autoscaling is actually enabled (true), ensuring manual scaling works as expected for false (and omitted/null).


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.
- [x] (For changes that include a **state migration only**). I have manually tested the migration path between relevant versions of the provider.


## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_kubernetes_cluster` - fix for the `node_count` property


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #144 